### PR TITLE
Fixed Remote Code Execution in im-metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(path, opts, cb) {
 }
 };
 
-module.exports.cmd = function(path, opts) {
+module.exports.cmd = function(path..split(";",1), opts) {
   opts = opts || {};
   var format = [
     'name=',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*jshint laxbreak:true */
 
 var sizeParser = require('filesize-parser');
-var exec = require('child_process').exec, child;
+var exec = require('child_process').execFile, child;
 
 module.exports = function(path, opts, cb) {
   if (!cb) {
@@ -12,7 +12,7 @@ module.exports = function(path, opts, cb) {
   if(/;|&|`|\$|\(|\)|\|\||\||!|>|<|\?|\${/g.test(JSON.stringify(path))) {
     console.log('Input Validation failed, Suspicious Characters found');
   } else {
-    var cmd = module.exports.cmd(path.split(";",1), opts);
+    var cmd = module.exports.cmd(path, opts);
     opts.timeout = opts.timeout || 5000;
     exec(cmd, opts, function(e, stdout, stderr) {
       if (e) { return cb(e); }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(path, opts, cb) {
   if(/;|&|`|\$|\(|\)|\|\||\||!|>|<|\?|\${/g.test(JSON.stringify(path))) {
     console.log('Input Validation failed, Suspicious Characters found');
   } else {
-    var cmd = module.exports.cmd(path, opts);
+    var cmd = module.exports.cmd(path.split(";",1), opts);
     opts.timeout = opts.timeout || 5000;
     exec(cmd, opts, function(e, stdout, stderr) {
       if (e) { return cb(e); }
@@ -23,7 +23,7 @@ module.exports = function(path, opts, cb) {
 }
 };
 
-module.exports.cmd = function(path..split(";",1), opts) {
+module.exports.cmd = function(path, opts) {
   opts = opts || {};
   var format = [
     'name=',


### PR DESCRIPTION
### 📊 Metadata *
Fixed Remote Code execution
#### Bounty URL:https://www.huntr.dev/bounties/1-npm-im-metadata/
### ⚙️ Description *
This Package helps to retrieve image metadata using ImageMagick's identify command
### 💻 Technical Description *
The Cause for RCE was providing a command immediately after the use of a semicolon at the path variable.
### 🐛 Proof of Concept (PoC) *
```javascript
//poc.js
metadata = require("im-metadata");
metadata(";calc.exe", {}, function () {});
```
![poc](https://user-images.githubusercontent.com/43377443/105460340-a872e180-5cb1-11eb-9854-2f074deb051b.PNG)
### 🔥 Proof of Fix (PoF) *
![pof](https://user-images.githubusercontent.com/43377443/105460563-fd165c80-5cb1-11eb-9a66-8d6aca03d367.PNG)

### 👍 User Acceptance Testing (UAT)
The PoC does not seem to be working after the fix being applied.