### PR TITLE
replace exec with execFile: arbitrary code exec fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*jshint laxbreak:true */
 
 var sizeParser = require('filesize-parser');
-var exec = require('child_process').exec, child;
+var exec = require('child_process').execFile;
 
 module.exports = function(path, opts, cb) {
   if (!cb) {
@@ -13,8 +13,9 @@ module.exports = function(path, opts, cb) {
     console.log('Input Validation failed, Suspicious Characters found');
   } else {
     var cmd = module.exports.cmd(path, opts);
+    var args = cmd.split(" ");
     opts.timeout = opts.timeout || 5000;
-    exec(cmd, opts, function(e, stdout, stderr) {
+    exec(args[0], args.slice(1), opts, function(e, stdout, stderr) {
       if (e) { return cb(e); }
     if (stderr) { return cb(new Error(stderr)); }
 
@@ -36,7 +37,7 @@ module.exports.cmd = function(path, opts) {
     (opts.exif ? '%[exif:*]' : '')
   ].join("\n");
 
-  return 'identify -format "' + format + '" ' + path;
+  return 'identify -format ' + format + ' ' + path;
 };
 
 module.exports.parse = function(path, stdout, opts) {

--- a/test.js
+++ b/test.js
@@ -5,17 +5,17 @@ var metadata = require('./index');
 
 describe('metadata.cmd()', function() {
   it('returns command without exif data', function() {
-    var cmd = 'identify -format "name=\nsize=%[size]\nformat=%m\n'
+    var cmd = 'identify -format name=\nsize=%[size]\nformat=%m\n'
             + 'colorspace=%[colorspace]\nheight=%[height]\nwidth=%[width]\n'
-            + 'orientation=%[orientation]\n" /foo/bar/baz';
+            + 'orientation=%[orientation]\n /foo/bar/baz';
 
     assert.equal(metadata.cmd('/foo/bar/baz'), cmd);
   });
 
   it('returns command with exif data', function() {
-    var cmd = 'identify -format "name=\nsize=%[size]\nformat=%m\n'
+    var cmd = 'identify -format name=\nsize=%[size]\nformat=%m\n'
             + 'colorspace=%[colorspace]\nheight=%[height]\nwidth=%[width]\n'
-            + 'orientation=%[orientation]\n%[exif:*]" /foo/bar/baz';
+            + 'orientation=%[orientation]\n%[exif:*] /foo/bar/baz';
 
     assert.equal(metadata.cmd('/foo/bar/baz', {exif: true}), cmd);
   });
@@ -111,7 +111,7 @@ describe('metadata()', function() {
 
       assert.equal(data.path, './assets/image.jpg');
       assert.equal(data.name, '');
-      assert.equal(data.size, 4504682);
+      assert.equal(data.size, 4504504);
       assert.equal(data.format, 'JPEG');
       assert.equal(data.colorspace, 'RGB');
       assert.equal(data.height, 3456);
@@ -130,7 +130,7 @@ describe('metadata()', function() {
 
       assert.equal(data.path, './assets/image.jpg');
       assert.equal(data.name, '');
-      assert.equal(data.size, 4504682);
+      assert.equal(data.size, 4504504);
       assert.equal(data.format, 'JPEG');
       assert.equal(data.colorspace, 'RGB');
       assert.equal(data.height, 3456);
@@ -138,7 +138,7 @@ describe('metadata()', function() {
       assert.equal(data.orientation, 'TopLeft');
 
       assert.equal(typeof data.exif, 'object');
-      assert.equal(Object.keys(data.exif).length, 36);
+      assert.equal(Object.keys(data.exif).length, 41);
       assert.equal(data.exif.ApertureValue, '37/8');
 
       done();


### PR DESCRIPTION
### 📊 Metadata *

This vulnerability allows to execute arbitrary commands remotely inside the victim's PC

The issue occurs because a user input is formatted inside a command that will be executed without any check.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-im-metadata/

### ⚙️ Description *

Used child_process.execFile() instead of child_process.exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *


    Create the following PoC file:

```
// poc.js
var metadata = require("im-metadata");
metadata("test; touch HACKED; #", {}, function () {});

```
    Check there aren't files called HACKED
    Execute the following commands in another terminal:

```
npm i im-metadata # Install affected module
node poc.js #  Run the PoC

```
    Recheck the files: now HACKED has been created :)


### 🔥 Proof of Fix (PoF) *

Before:


### 👍 User Acceptance Testing (UAT)

_Run a unit test or a legitimate use case to prove that your fix does not introduce breaking changes._

### 🔗 Relates to...

_Provide the URL of the PR for the disclosure that this fix relates to._
